### PR TITLE
Ignore input lines starting with `#` (comments)

### DIFF
--- a/main/builtin-shell.go
+++ b/main/builtin-shell.go
@@ -11,7 +11,7 @@ func (b builtinShell) init() error {
 }
 
 func (b builtinShell) filter(command string) bool {
-	return strings.HasPrefix(command, ";")
+	return strings.HasPrefix(command, ";") || strings.HasPrefix(command, "#")
 }
 
 func (b builtinShell) run(command string) error {

--- a/main/main.go
+++ b/main/main.go
@@ -56,7 +56,7 @@ func repl(commands Commands) error {
 		return err
 	}
 
-	if strings.TrimSpace(command) == "" {
+	if trimmed := strings.TrimSpace(command); trimmed == "" || strings.HasPrefix(trimmed, "#") {
 		return nil
 	}
 

--- a/main/main.go
+++ b/main/main.go
@@ -41,7 +41,7 @@ func prompt() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	response := strings.Trim(line, "\n")
+	response := strings.TrimSpace(line)
 	return substituteForVars(response)
 }
 
@@ -56,7 +56,7 @@ func repl(commands Commands) error {
 		return err
 	}
 
-	if trimmed := strings.TrimSpace(command); trimmed == "" || strings.HasPrefix(trimmed, "#") {
+	if command == "" {
 		return nil
 	}
 


### PR DESCRIPTION
Readline (and thus rlwrap) has the ability to comment out the current
input line by pressing <kbd>esc</kbd> followed by <kbd>#</kbd>. However, kubectl-repl will
execute this as `kubectl #insert comment here` which shows the help
text. This updates the repl to ignore lines beginning with `#`.